### PR TITLE
Add option to output both splitted and merged RLV INFO fields

### DIFF
--- a/src/main/java/org/molgenis/data/annotation/makervcf/RlvInfoMapper.java
+++ b/src/main/java/org/molgenis/data/annotation/makervcf/RlvInfoMapper.java
@@ -1,5 +1,6 @@
 package org.molgenis.data.annotation.makervcf;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.molgenis.data.annotation.makervcf.structs.RVCF.FIELD_NAME;
 import static org.molgenis.data.annotation.makervcf.structs.RVCFUtils.createRvcfValues;
 
@@ -20,85 +21,87 @@ import org.molgenis.data.annotation.makervcf.structs.Relevance;
 public class RlvInfoMapper
 {
 
-	private StringBuffer infoField = new StringBuffer();
+  public String map(List<Relevance> relevanceList, RlvMode rlvMode, boolean prefixRlvFields) {
+    StringBuffer infoField = new StringBuffer();
+    if (!relevanceList.isEmpty()) {
+      List<RVCF> rvcfList = mapRelevanceListToRVcfList(relevanceList);
 
-	public String map(List<Relevance> relevanceList, RlvMode rlvMode, boolean prefixRlvFields)
-	{
-		if(!relevanceList.isEmpty())
-		{
-			List<RVCF> rvcfList = new ArrayList<>();
-			for (Relevance rlv : relevanceList)
-			{
-				RVCF rvcf = new RVCF();
+      if (rlvMode == RlvMode.SPLITTED || rlvMode == RlvMode.BOTH) {
+        infoField.append(getSplittedFields(rvcfList, prefixRlvFields));
+      }
+      if (rlvMode == RlvMode.MERGED || rlvMode == RlvMode.BOTH) {
+        infoField.append(getMergedFields(rvcfList));
+      }
+    } else {
+      if (rlvMode == RlvMode.SPLITTED || rlvMode == RlvMode.BOTH) {
+        infoField.append(RVCF.RLV_PRESENT + "=" + "FALSE");
+      }
+      if (rlvMode == RlvMode.MERGED || rlvMode == RlvMode.BOTH) {
+        if (!(infoField.length() == 0)) {
+          infoField.append(",");
+        }
+        infoField.append(RVCF.FIELD_NAME + "=" + RVCFUtils.EMPTY_VALUE);
+      }
+    }
+    return infoField.toString();
+  }
 
-				rvcf.setGene(rlv.getGene());
-				rvcf.setFDR(rlv.getFDR());
-				rvcf.setAllele(rlv.getAllele());
-				rvcf.setAlleleFreq(String.valueOf(rlv.getAlleleFreq()));
-				Optional<String> transcript = rlv.getTranscript();
-				rvcf.setTranscript(transcript.orElse(""));
+  private List<RVCF> mapRelevanceListToRVcfList(List<Relevance> relevanceList) {
+    List<RVCF> rvcfList = newArrayList();
+    for (Relevance rlv : relevanceList) {
+      RVCF rvcf = new RVCF();
 
-				if (rlv.getCgdInfo() != null)
-				{
-					rvcf.setPhenotype(rlv.getCgdInfo().getCondition());
-					rvcf.setPhenotypeInheritance(rlv.getCgdInfo().getGeneralizedInheritance().toString());
-					rvcf.setPhenotypeOnset(rlv.getCgdInfo().getAge_group());
-					rvcf.setPhenotypeDetails(rlv.getCgdInfo().getComments());
-					rvcf.setPhenotypeGroup(null);
-				}
+      rvcf.setGene(rlv.getGene());
+      rvcf.setFDR(rlv.getFDR());
+      rvcf.setAllele(rlv.getAllele());
+      rvcf.setAlleleFreq(String.valueOf(rlv.getAlleleFreq()));
+      Optional<String> transcript = rlv.getTranscript();
+      rvcf.setTranscript(transcript.orElse(""));
 
-				rvcf.setVariantSignificance(rlv.getJudgment().getType());
-				rvcf.setVariantSignificanceSource(rlv.getJudgment().getSource());
-				rvcf.setVariantSignificanceJustification(rlv.getJudgment().getReason());
-				rvcf.setVariantMultiGenic(null);
-				rvcf.setVariantGroup(null);
+      if (rlv.getCgdInfo() != null) {
+        rvcf.setPhenotype(rlv.getCgdInfo().getCondition());
+        rvcf.setPhenotypeInheritance(rlv.getCgdInfo().getGeneralizedInheritance().toString());
+        rvcf.setPhenotypeOnset(rlv.getCgdInfo().getAge_group());
+        rvcf.setPhenotypeDetails(rlv.getCgdInfo().getComments());
+        rvcf.setPhenotypeGroup(null);
+      }
 
-				rvcf.setSampleStatus(rlv.getSampleStatus());
-				rvcf.setSampleGenotype(rlv.getSampleGenotypes());
-				rvcf.setSamplePhenotype(null);
-				rvcf.setSampleGroup(null);
+      rvcf.setVariantSignificance(rlv.getJudgment().getType());
+      rvcf.setVariantSignificanceSource(rlv.getJudgment().getSource());
+      rvcf.setVariantSignificanceJustification(rlv.getJudgment().getReason());
+      rvcf.setVariantMultiGenic(null);
+      rvcf.setVariantGroup(null);
 
-				rvcfList.add(rvcf);
-			}
+      rvcf.setSampleStatus(rlv.getSampleStatus());
+      rvcf.setSampleGenotype(rlv.getSampleGenotypes());
+      rvcf.setSamplePhenotype(null);
+      rvcf.setSampleGroup(null);
 
-			if (rlvMode == RlvMode.SPLITTED || rlvMode == RlvMode.BOTH)
-			{
-				Map<String, String> rvcfValues = new HashMap<>();
-				for (RVCF rvcf : rvcfList)
-				{
-					rvcfValues = createRvcfValues(rvcf, rvcfValues, prefixRlvFields);
-				}
-				List<String> rlvInfoFields = new ArrayList<>();
-				for(Map.Entry<String,String> entry : rvcfValues.entrySet()){
-					rlvInfoFields.add(entry.getKey() +"="+ entry.getValue());
-				}
-				infoField.append(Strings.join(rlvInfoFields, ";"));
-			}
-			if (rlvMode == RlvMode.MERGED || rlvMode == RlvMode.BOTH)
-			{
-				List<String> rvcfStringList = new ArrayList<>();
-				for (RVCF rvcf : rvcfList)
-				{
-					rvcfStringList.add(RVCFUtils.getMergedFieldVcfString(rvcf));
-				}
-				if (!(infoField.length() == 0)) {
-					infoField.append(",");
-				}
-				infoField.append(FIELD_NAME + "=" + Strings.join(rvcfStringList, ","));
-			}
-		}
-		else{
-			if (rlvMode == RlvMode.SPLITTED || rlvMode == RlvMode.BOTH)
-			{
-				infoField.append(RVCF.RLV_PRESENT + "=" + "FALSE");
-			}
-			if (rlvMode == RlvMode.MERGED || rlvMode == RlvMode.BOTH) {
-				if (!(infoField.length() == 0)) {
-					infoField.append(",");
-				}
-				infoField.append(RVCF.FIELD_NAME + "=" + RVCFUtils.EMPTY_VALUE);
-			}
-		}
-		return infoField.toString();
-	}
+      rvcfList.add(rvcf);
+    }
+    return rvcfList;
+  }
+
+  private String getSplittedFields(List<RVCF> rvcfList, boolean prefixRlvFields) {
+    Map<String, String> rvcfValues = new HashMap<>();
+    for (RVCF rvcf : rvcfList) {
+      rvcfValues = createRvcfValues(rvcf, rvcfValues, prefixRlvFields);
+    }
+    List<String> rlvInfoFields = new ArrayList<>();
+    for (Map.Entry<String, String> entry : rvcfValues.entrySet()) {
+      rlvInfoFields.add(entry.getKey() + "=" + entry.getValue());
+    }
+    return Strings.join(rlvInfoFields, ";");
+  }
+
+  private String getMergedFields(List<RVCF> rvcfList) {
+    List<String> rvcfStringList = new ArrayList<>();
+    StringBuffer infoField = new StringBuffer();
+    infoField.append(FIELD_NAME + "=");
+    for (RVCF rvcf : rvcfList) {
+      rvcfStringList.add(RVCFUtils.getMergedFieldVcfString(rvcf));
+    }
+    infoField.append(Strings.join(rvcfStringList, ","));
+    return infoField.toString();
+  }
 }

--- a/src/main/java/org/molgenis/data/annotation/makervcf/VcfRecordMapper.java
+++ b/src/main/java/org/molgenis/data/annotation/makervcf/VcfRecordMapper.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.stream.StreamSupport;
 import joptsimple.internal.Strings;
 import org.molgenis.data.annotation.core.entity.impl.snpeff.Annotation;
+import org.molgenis.data.annotation.makervcf.Main.RlvMode;
 import org.molgenis.data.annotation.makervcf.structs.AnnotatedVcfRecord;
 import org.molgenis.data.annotation.makervcf.structs.GavinRecord;
 import org.molgenis.data.annotation.makervcf.structs.Relevance;
@@ -116,7 +117,7 @@ class VcfRecordMapper {
       stringBuilder.append(';');
     }
     if (!gavinRecord.getRelevance().isEmpty()) {
-      stringBuilder.append(getRlv(gavinRecord, vcfRecordMapperSettings.splitRlvField(),
+      stringBuilder.append(getRlv(gavinRecord, vcfRecordMapperSettings.rlvMode(),
           vcfRecordMapperSettings.prefixSplittedRlvFields()));
     } else {
       stringBuilder.append(createInfoTokenPart(RLV_PRESENT, "FALSE"));
@@ -152,12 +153,12 @@ class VcfRecordMapper {
     return stream(formatTokens).collect(joining(":"));
   }
 
-  private String getRlv(GavinRecord gavinRecord, boolean splitRlvField,
+  private String getRlv(GavinRecord gavinRecord, RlvMode rlvMode,
       boolean prefixSplittedFields) {
     LOG.debug("[MakeRVCFforClinicalVariants] Looking at: {}", gavinRecord);
 
     List<Relevance> relevance = gavinRecord.getRelevance();
-    String rlv = rlvInfoMapper.map(relevance, splitRlvField, prefixSplittedFields);
+    String rlv = rlvInfoMapper.map(relevance, rlvMode, prefixSplittedFields);
 
     LOG.debug(
         "[MakeRVCFforClinicalVariants] Converted relevant variant to a VCF INFO field for writing out: {}",

--- a/src/main/java/org/molgenis/data/annotation/makervcf/VcfRecordMapperSettings.java
+++ b/src/main/java/org/molgenis/data/annotation/makervcf/VcfRecordMapperSettings.java
@@ -1,22 +1,23 @@
 package org.molgenis.data.annotation.makervcf;
 
 import com.google.auto.value.AutoValue;
+import org.molgenis.data.annotation.makervcf.Main.RlvMode;
 
 @AutoValue
 public abstract class VcfRecordMapperSettings
 {
 	public abstract boolean includeSamples();
 
-	public abstract boolean splitRlvField();
+	public abstract RlvMode rlvMode();
 
 	public abstract boolean addSplittedAnnFields();
 
 	public abstract boolean prefixSplittedRlvFields();
 
-	public static VcfRecordMapperSettings create(boolean includeSamples, boolean splitRlvField,
+	public static VcfRecordMapperSettings create(boolean includeSamples, RlvMode rlvMode,
 			boolean addSplittedAnnFields, boolean prefixSplittedRlvFields)
 	{
-		return new AutoValue_VcfRecordMapperSettings(includeSamples, splitRlvField, addSplittedAnnFields,
+		return new AutoValue_VcfRecordMapperSettings(includeSamples, rlvMode, addSplittedAnnFields,
 				prefixSplittedRlvFields);
 	}
 }

--- a/src/test/java/org/molgenis/data/annotation/makervcf/VcfRecordMapperTest.java
+++ b/src/test/java/org/molgenis/data/annotation/makervcf/VcfRecordMapperTest.java
@@ -1,8 +1,18 @@
 package org.molgenis.data.annotation.makervcf;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockitoSession;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
 import org.mockito.Mock;
 import org.mockito.MockitoSession;
 import org.molgenis.data.annotation.core.entity.impl.gavin.Judgment;
+import org.molgenis.data.annotation.makervcf.Main.RlvMode;
 import org.molgenis.data.annotation.makervcf.structs.AnnotatedVcfRecord;
 import org.molgenis.data.annotation.makervcf.structs.GavinRecord;
 import org.molgenis.data.annotation.makervcf.structs.Relevance;
@@ -13,14 +23,6 @@ import org.molgenis.vcf.meta.VcfMeta;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.Optional;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static org.mockito.Mockito.*;
-import static org.mockito.quality.Strictness.STRICT_STUBS;
-import static org.testng.Assert.assertEquals;
 
 public class VcfRecordMapperTest
 {
@@ -71,7 +73,7 @@ public class VcfRecordMapperTest
 	@Test
 	public void testMapSplitRlv()
 	{
-		when(vcfRecordMapperSettings.splitRlvField()).thenReturn(true);
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.SPLITTED);
 		when(vcfRecordMapperSettings.prefixSplittedRlvFields()).thenReturn(true);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(true, true, true, true, true, true, false);
@@ -82,9 +84,21 @@ public class VcfRecordMapperTest
 	}
 
 	@Test
+	public void testMapSplittedAndMergedRlv() {
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.BOTH);
+		when(vcfRecordMapperSettings.prefixSplittedRlvFields()).thenReturn(true);
+		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
+		GavinRecord gavinRecord = createMock(true, true, true, true, true, true, false);
+		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
+		assertEquals(mappedVcfRecord, new VcfRecord(vcfMeta,
+				new String[]{"1", "123", "rs6054257;rs6040355", "GTC", "G,GTCT", "123.45", "q10;s50",
+						"key0=val0;key1=val1;RLV_ALLELEFREQ=[A|gene0]0.1,[G|gene1]3.4;RLV_SAMPLEGENOTYPE=[A|gene0].,[G|gene1].;RLV_VARIANTGROUP=[A|gene0].,[G|gene1].;RLV_SAMPLEGROUP=[A|gene0].,[G|gene1].;RLV_FDR=[A|gene0].,[G|gene1].;RLV_PHENOTYPEINHERITANCE=[A|gene0].,[G|gene1].;RLV_ALLELE=[A|gene0]A,[G|gene1]G;RLV_GENE=[A|gene0]gene0,[G|gene1]gene1;RLV_PHENOTYPE=[A|gene0].,[G|gene1].;RLV_PHENOTYPEDETAILS=[A|gene0].,[G|gene1].;RLV_PHENOTYPEGROUP=[A|gene0].,[G|gene1].;RLV_VARIANTSIGNIFICANCE=[A|gene0]type0,[G|gene1]type1;RLV_VARIANTSIGNIFICANCEJUSTIFICATION=[A|gene0]my_reason_#0,[G|gene1]my_reason_#1;RLV_TRANSCRIPT=[A|gene0]transcript0,[G|gene1]transcript1;RLV_PRESENT=[A|gene0]TRUE,[G|gene1]TRUE;RLV_SAMPLESTATUS=[A|gene0].,[G|gene1].;RLV_VARIANTSIGNIFICANCESOURCE=[A|gene0]source0,[G|gene1]source1;RLV_VARIANTMULTIGENIC=[A|gene0].,[G|gene1].;RLV_PHENOTYPEONSET=[A|gene0].,[G|gene1].;RLV_SAMPLEPHENOTYPE=[A|gene0].,[G|gene1].,RLV=A|0.1|gene0||transcript0||||||||||type0|source0|my_reason_#0||,G|3.4|gene1||transcript1||||||||||type1|source1|my_reason_#1||"}));
+	}
+
+	@Test
 	public void testMapSplitRlvNoPrefix()
 	{
-		when(vcfRecordMapperSettings.splitRlvField()).thenReturn(true);
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.SPLITTED);
 		when(vcfRecordMapperSettings.prefixSplittedRlvFields()).thenReturn(false);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(true, true, true, true, true, true, false);

--- a/src/test/java/org/molgenis/data/annotation/makervcf/VcfRecordMapperTest.java
+++ b/src/test/java/org/molgenis/data/annotation/makervcf/VcfRecordMapperTest.java
@@ -51,6 +51,7 @@ public class VcfRecordMapperTest
 	{
 		GavinRecord gavinRecord = createMock(true, true, true, true, true, true, true);
 		when(vcfRecordMapperSettings.includeSamples()).thenReturn(true);
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
 
@@ -62,6 +63,7 @@ public class VcfRecordMapperTest
 	@Test
 	public void testMapNoSamples()
 	{
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(true, true, true, true, true, true, false);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
@@ -92,7 +94,7 @@ public class VcfRecordMapperTest
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
 		assertEquals(mappedVcfRecord, new VcfRecord(vcfMeta,
 				new String[]{"1", "123", "rs6054257;rs6040355", "GTC", "G,GTCT", "123.45", "q10;s50",
-						"key0=val0;key1=val1;RLV_ALLELEFREQ=[A|gene0]0.1,[G|gene1]3.4;RLV_SAMPLEGENOTYPE=[A|gene0].,[G|gene1].;RLV_VARIANTGROUP=[A|gene0].,[G|gene1].;RLV_SAMPLEGROUP=[A|gene0].,[G|gene1].;RLV_FDR=[A|gene0].,[G|gene1].;RLV_PHENOTYPEINHERITANCE=[A|gene0].,[G|gene1].;RLV_ALLELE=[A|gene0]A,[G|gene1]G;RLV_GENE=[A|gene0]gene0,[G|gene1]gene1;RLV_PHENOTYPE=[A|gene0].,[G|gene1].;RLV_PHENOTYPEDETAILS=[A|gene0].,[G|gene1].;RLV_PHENOTYPEGROUP=[A|gene0].,[G|gene1].;RLV_VARIANTSIGNIFICANCE=[A|gene0]type0,[G|gene1]type1;RLV_VARIANTSIGNIFICANCEJUSTIFICATION=[A|gene0]my_reason_#0,[G|gene1]my_reason_#1;RLV_TRANSCRIPT=[A|gene0]transcript0,[G|gene1]transcript1;RLV_PRESENT=[A|gene0]TRUE,[G|gene1]TRUE;RLV_SAMPLESTATUS=[A|gene0].,[G|gene1].;RLV_VARIANTSIGNIFICANCESOURCE=[A|gene0]source0,[G|gene1]source1;RLV_VARIANTMULTIGENIC=[A|gene0].,[G|gene1].;RLV_PHENOTYPEONSET=[A|gene0].,[G|gene1].;RLV_SAMPLEPHENOTYPE=[A|gene0].,[G|gene1].,RLV=A|0.1|gene0||transcript0||||||||||type0|source0|my_reason_#0||,G|3.4|gene1||transcript1||||||||||type1|source1|my_reason_#1||"}));
+						"key0=val0;key1=val1;RLV_ALLELEFREQ=[A|gene0]0.1,[G|gene1]3.4;RLV_SAMPLEGENOTYPE=[A|gene0].,[G|gene1].;RLV_VARIANTGROUP=[A|gene0].,[G|gene1].;RLV_SAMPLEGROUP=[A|gene0].,[G|gene1].;RLV_FDR=[A|gene0].,[G|gene1].;RLV_PHENOTYPEINHERITANCE=[A|gene0].,[G|gene1].;RLV_ALLELE=[A|gene0]A,[G|gene1]G;RLV_GENE=[A|gene0]gene0,[G|gene1]gene1;RLV_PHENOTYPE=[A|gene0].,[G|gene1].;RLV_PHENOTYPEDETAILS=[A|gene0].,[G|gene1].;RLV_PHENOTYPEGROUP=[A|gene0].,[G|gene1].;RLV_VARIANTSIGNIFICANCE=[A|gene0]type0,[G|gene1]type1;RLV_VARIANTSIGNIFICANCEJUSTIFICATION=[A|gene0]my_reason_#0,[G|gene1]my_reason_#1;RLV_TRANSCRIPT=[A|gene0]transcript0,[G|gene1]transcript1;RLV_PRESENT=[A|gene0]TRUE,[G|gene1]TRUE;RLV_SAMPLESTATUS=[A|gene0].,[G|gene1].;RLV_VARIANTSIGNIFICANCESOURCE=[A|gene0]source0,[G|gene1]source1;RLV_VARIANTMULTIGENIC=[A|gene0].,[G|gene1].;RLV_PHENOTYPEONSET=[A|gene0].,[G|gene1].;RLV_SAMPLEPHENOTYPE=[A|gene0].,[G|gene1].RLV=A|0.1|gene0||transcript0||||||||||type0|source0|my_reason_#0||,G|3.4|gene1||transcript1||||||||||type1|source1|my_reason_#1||"}));
 	}
 
 	@Test
@@ -111,6 +113,7 @@ public class VcfRecordMapperTest
 	@Test
 	public void testMapNoIdentifiers()
 	{
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(false, true, true, true, true, true, false);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
@@ -122,6 +125,7 @@ public class VcfRecordMapperTest
 	@Test
 	public void testMapNoAlt()
 	{
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(true, false, true, true, true, true, false);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
@@ -133,6 +137,7 @@ public class VcfRecordMapperTest
 	@Test
 	public void testMapNoQuality()
 	{
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(true, true, false, true, true, true, false);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
@@ -145,6 +150,7 @@ public class VcfRecordMapperTest
 	public void testMapNoFilterStatus()
 	{
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		GavinRecord gavinRecord = createMock(true, true, true, false, true, true, false);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);
 		assertEquals(mappedVcfRecord, new VcfRecord(vcfMeta,
@@ -166,6 +172,7 @@ public class VcfRecordMapperTest
 	@Test
 	public void testMapNoInfo()
 	{
+		when(vcfRecordMapperSettings.rlvMode()).thenReturn(RlvMode.MERGED);
 		vcfRecordMapper = new VcfRecordMapper(vcfMeta, vcfRecordMapperSettings);
 		GavinRecord gavinRecord = createMock(true, true, true, true, true, false, false);
 		VcfRecord mappedVcfRecord = vcfRecordMapper.map(gavinRecord);

--- a/src/test/java/org/molgenis/data/annotation/makervcf/WriteToRVCFTest.java
+++ b/src/test/java/org/molgenis/data/annotation/makervcf/WriteToRVCFTest.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Scanner;
 import org.apache.commons.io.FileUtils;
+import org.molgenis.data.annotation.makervcf.Main.RlvMode;
 import org.molgenis.data.annotation.makervcf.positionalstream.DiscoverRelevantVariants;
 import org.molgenis.data.annotation.makervcf.positionalstream.MatchVariantsToGenotypeAndInheritance;
 import org.molgenis.data.annotation.makervcf.structs.GavinRecord;
@@ -93,7 +94,8 @@ public class WriteToRVCFTest extends Setup
 		Iterator<GavinRecord> match = new MatchVariantsToGenotypeAndInheritance(discover.findRelevantVariants(),
 				cgdFile, new HashSet<String>()).go();
 
-		VcfRecordMapperSettings vcfRecordMapperSettings = VcfRecordMapperSettings.create(false, false, false, false);
+		VcfRecordMapperSettings vcfRecordMapperSettings = VcfRecordMapperSettings
+				.create(false, RlvMode.MERGED, false, false);
 		new WriteToRVCF().writeRVCF(match, observedOutputVcfFile, inputVcfFile, "test", "command", true,
 				vcfRecordMapperSettings);
 
@@ -115,7 +117,8 @@ public class WriteToRVCFTest extends Setup
 		Iterator<GavinRecord> match = new MatchVariantsToGenotypeAndInheritance(discover.findRelevantVariants(),
 				cgdFile, new HashSet<String>()).go();
 
-		VcfRecordMapperSettings vcfRecordMapperSettings = VcfRecordMapperSettings.create(false, false, false, false);
+		VcfRecordMapperSettings vcfRecordMapperSettings = VcfRecordMapperSettings
+				.create(false, RlvMode.MERGED, false, false);
 		new WriteToRVCF().writeRVCF(match, observedOutputVcfFile, inputVcfFile, "test", "command", true,
 				vcfRecordMapperSettings);
 
@@ -137,7 +140,8 @@ public class WriteToRVCFTest extends Setup
 		Iterator<GavinRecord> match = new MatchVariantsToGenotypeAndInheritance(discover.findRelevantVariants(),
 				cgdFile, new HashSet<String>()).go();
 
-		VcfRecordMapperSettings vcfRecordMapperSettings = VcfRecordMapperSettings.create(false, false, true, false);
+		VcfRecordMapperSettings vcfRecordMapperSettings = VcfRecordMapperSettings
+				.create(false, RlvMode.MERGED, true, false);
 		new WriteToRVCF().writeRVCF(match, observedOutputVcfFile, inputVcfFile, "test", "command", true,
 				vcfRecordMapperSettings);
 


### PR DESCRIPTION
changed cmd line option "q" from: "Create separate INFO fields for every part of the RLV information"
to
"The format mode of the RLV field: MERGED (single pipe separated field), SPLITTED(info field per RLV attr), BOTH(both the merged and splitted fields)"